### PR TITLE
Fix project description text wrapping in ProjectCard

### DIFF
--- a/src/renderer/components/data-display/project-card.tsx
+++ b/src/renderer/components/data-display/project-card.tsx
@@ -116,7 +116,13 @@ export const ProjectCard: FC<Props> = ({ project }) => {
               </StyledLink>
             </Typography>
             {project.description !== "" && (
-              <Typography component="pre">
+              <Typography
+                component="pre"
+                sx={{
+                  wordWrap: "normal",
+                  whiteSpace: "normal",
+                }}
+              >
                 {project.description}
               </Typography>
             )}


### PR DESCRIPTION
Updated the Typography component for project descriptions to use normal word wrapping and white space handling. This ensures long descriptions are displayed correctly without overflow.