### PR TITLE
Refactor project query and tag routes, update db path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "commonjs",
   "name": "project-sapphire",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Project Sapphire",
   "main": "./out/main/index.js",
   "author": "https://github.com/eurydia",

--- a/src/main/db/data-source.ts
+++ b/src/main/db/data-source.ts
@@ -6,7 +6,7 @@ import { migrations } from "./migrations"
 export const AppDataSource = new DataSource({
   type: "better-sqlite3",
   database: app.isPackaged
-    ? `sapphire-database.${app.getVersion()}.sqlite`
+    ? `${app.getPath("userData")}/db/sapphire-database.${app.getVersion()}.sqlite`
     : `sapphire-database.sqlite`,
   entities,
   subscribers: [],

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -53,6 +53,7 @@ function createWindow(): void {
 app.whenReady().then(async () => {
   const ds = await AppDataSource.initialize()
   await ds.runMigrations()
+
   // Set app user model id for windows
   electronApp.setAppUserModelId("io.github.eurydia")
 

--- a/src/renderer/components/data-display/project-card.tsx
+++ b/src/renderer/components/data-display/project-card.tsx
@@ -91,14 +91,20 @@ export const ProjectCard: FC<Props> = ({ project }) => {
             >
               {project.uuid}
             </Typography>
-            {/* <Typography
+            <Typography
               variant="subtitle2"
               color="textSecondary"
             >
-              {project.root.path}
-            </Typography> */}
+              {`${project.workspaces.length} ${project.workspaces.length <= 1 ? "work space" : "work spaces"}`}
+            </Typography>
+            <Typography
+              variant="subtitle2"
+              color="textSecondary"
+            >
+              {`${project.repositories.length} ${project.repositories.length <= 1 ? "repository" : "repositories"}`}
+            </Typography>
           </Stack>
-          <Stack>
+          <Stack spacing={1}>
             <Typography
               variant="h4"
               component="div"

--- a/src/renderer/components/form/project-query-form.tsx
+++ b/src/renderer/components/form/project-query-form.tsx
@@ -1,18 +1,16 @@
-import type { ProjectPaginationQuery } from "#/models/project/dto/pagination-project.dto"
 import { Autocomplete, Stack, TextField } from "@mui/material"
 import { memo, useMemo, useRef, useState, type FC } from "react"
 import { useHotkeys } from "react-hotkeys-hook"
 import { StyledLink } from "../navigation/styled-link"
 
 type Props = {
-  search: ProjectPaginationQuery
   formOptions: {
     tags: string[]
     projects: string[]
   }
 }
 export const ProjectQueryForm: FC<Props> = memo(
-  ({ formOptions, search }) => {
+  ({ formOptions }) => {
     const options = useMemo(() => {
       return formOptions.tags
         .map((opt) => [
@@ -73,7 +71,6 @@ export const ProjectQueryForm: FC<Props> = memo(
           <StyledLink
             to="/projects"
             search={{
-              ...search,
               query: value.map(({ value }) => value),
             }}
           >

--- a/src/renderer/routes/project-tags/$uuid/index.tsx
+++ b/src/renderer/routes/project-tags/$uuid/index.tsx
@@ -21,15 +21,15 @@ export const Route = createFileRoute("/project-tags/$uuid/")({
     if (entry === null) {
       throw notFound()
     }
-    const pagination = await ProjectService.list({
-      query: [`tag:${entry.name}`],
-    })
-    return { entry, pagination }
+    const projects = await ProjectService.list([
+      `tag:${entry.name}`,
+    ])
+    return { entry, projects }
   },
 })
 
 function RouteComponent() {
-  const { entry, pagination } = Route.useLoaderData()
+  const { entry, projects } = Route.useLoaderData()
   return (
     <Grid spacing={1} container>
       <Grid size={{ md: 12 }}>
@@ -77,7 +77,7 @@ function RouteComponent() {
         </Paper>
       </Grid>
       <Grid size={{ md: 9 }}>
-        <ProjectList projects={pagination.items} />
+        <ProjectList projects={projects} />
       </Grid>
     </Grid>
   )

--- a/src/renderer/routes/projects/index.tsx
+++ b/src/renderer/routes/projects/index.tsx
@@ -18,17 +18,13 @@ import { z } from "zod/v4"
 
 const RouteComponent: FC = () => {
   const { projects, formOptions } = Route.useLoaderData()
-  const search = Route.useSearch()
   const router = useRouter()
 
   return (
     <Grid container spacing={1}>
       <Grid size={12}>
         <Paper variant="outlined">
-          <ProjectQueryForm
-            search={search}
-            formOptions={formOptions}
-          />
+          <ProjectQueryForm formOptions={formOptions} />
         </Paper>
       </Grid>
       <Grid size={{ sm: 12, md: 4 }}>


### PR DESCRIPTION
Refactored project tag route loader to return a flat projects array instead of a pagination object, and updated all usages accordingly. Simplified ProjectQueryForm props by removing the unused 'search' prop. Updated the database file path to use the userData directory when packaged. Enhanced ProjectCard to display workspace and repository counts.