### PR TITLE
Add 'Open DB' button and openDatabasePath IPC service

### DIFF
--- a/src/main/services/fs.ts
+++ b/src/main/services/fs.ts
@@ -1,5 +1,5 @@
 import { OpenDirDialogResult } from "#/results/open-dir-dialog.result"
-import { dialog, shell } from "electron"
+import { app, dialog, shell } from "electron"
 import { existsSync } from "fs"
 import { join, normalize } from "path"
 import { z } from "zod/v4"
@@ -54,8 +54,13 @@ const openURL = async (arg: unknown) => {
   return shell.openExternal(url, {})
 }
 
+const openDatabasePath = async () => {
+  return shell.openPath(join(app.getPath("userData"), "db"))
+}
+
 registerIpcMainServices("fs", {
   openDirDialog,
   openPath,
   openURL,
+  openDatabasePath,
 })

--- a/src/preload/fs.gen.d.ts
+++ b/src/preload/fs.gen.d.ts
@@ -1,7 +1,7 @@
 export declare global {
       interface Window {
         ["fs"]: {
-          openDirDialog: (...args: any[]) => Promise<unknown>,openPath: (...args: any[]) => Promise<unknown>,openURL: (...args: any[]) => Promise<unknown>
+          openDirDialog: (...args: any[]) => Promise<unknown>,openPath: (...args: any[]) => Promise<unknown>,openURL: (...args: any[]) => Promise<unknown>,openDatabasePath: (...args: any[]) => Promise<unknown>
         }
       }
     }

--- a/src/renderer/api/file-system.service.ts
+++ b/src/renderer/api/file-system.service.ts
@@ -20,4 +20,11 @@ export class FileSystemService {
       .then((resp) => right(resp))
       .catch((err) => left(err))
   }
+
+  static async openDbPath() {
+    return this.provider
+      .openDatabasePath()
+      .then((resp) => right(resp))
+      .catch((err) => left(err))
+  }
 }

--- a/src/renderer/routes/index.tsx
+++ b/src/renderer/routes/index.tsx
@@ -1,15 +1,49 @@
+import { FileSystemService } from "@/api/file-system.service"
+import { TypographyButton } from "@/components/input/typography-button"
 import { StyledLink } from "@/components/navigation/styled-link"
-import { Paper, Stack } from "@mui/material"
+import {
+  Divider,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+} from "@mui/material"
 import { createFileRoute } from "@tanstack/react-router"
 
 const RouteComponent = () => {
   return (
     <Stack spacing={1}>
       <Paper>
-        <StyledLink to="/projects">{`[PROJECTS]`}</StyledLink>
-      </Paper>
-      <Paper>
-        <StyledLink to="/project-tags">{`[PROJECT TAGS]`}</StyledLink>
+        <Stack spacing={2}>
+          <TypographyButton
+            onClick={() => FileSystemService.openDbPath()}
+          >
+            [OPEN DB]
+          </TypographyButton>
+          <Divider />
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>NAME</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              <TableRow>
+                <TableCell>
+                  <StyledLink to="/projects">{`[PROJECTS]`}</StyledLink>
+                </TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>
+                  <StyledLink to="/project-tags">{`[PROJECT TAGS]`}</StyledLink>
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </Stack>
       </Paper>
     </Stack>
   )


### PR DESCRIPTION
Introduces a new IPC service 'openDatabasePath' to open the application's database directory. Updates the renderer to include an '[OPEN DB]' button on the main route, refactors the UI to use a table for navigation links, and exposes the new service in the FileSystemService and preload typings.