### PR TITLE
Add TypeORM subscriber to sort project relations

### DIFF
--- a/scripts/data-source.migration.ts
+++ b/scripts/data-source.migration.ts
@@ -8,4 +8,5 @@ export default new DataSource({
   logging: false,
   entities: ["src/main/db/entities/**/*.entity.ts"],
   migrations: ["src/main/db/migrations/**/*-Auto.ts"],
+  subscribers: ["src/main/db/subscribers/**/*.subscriber.ts"],
 })

--- a/src/main/db/data-source.ts
+++ b/src/main/db/data-source.ts
@@ -2,6 +2,7 @@ import { app } from "electron"
 import { DataSource } from "typeorm"
 import { entities } from "./entities"
 import { migrations } from "./migrations"
+import { subscribers } from "./subscribers"
 
 export const AppDataSource = new DataSource({
   type: "better-sqlite3",
@@ -9,6 +10,6 @@ export const AppDataSource = new DataSource({
     ? `${app.getPath("userData")}/db/sapphire-database.${app.getVersion()}.sqlite`
     : `sapphire-database.sqlite`,
   entities,
-  subscribers: [],
+  subscribers,
   migrations,
 })

--- a/src/main/db/subscribers/index.ts
+++ b/src/main/db/subscribers/index.ts
@@ -1,0 +1,7 @@
+export const subscribers = Object.values(
+  import.meta.glob("./*.subscriber.ts", {
+    eager: true,
+  }),
+)
+  .flatMap((m: any) => Object.values(m))
+  .filter((v): v is Function => typeof v === "function")

--- a/src/main/db/subscribers/sort-project-relations.subscriber.ts
+++ b/src/main/db/subscribers/sort-project-relations.subscriber.ts
@@ -1,0 +1,47 @@
+import {
+  EntitySubscriberInterface,
+  EventSubscriber,
+} from "typeorm"
+import { ProjectEntity } from "../entities/project.entity"
+
+@EventSubscriber()
+export class SortProjectRelations
+  implements EntitySubscriberInterface<ProjectEntity>
+{
+  listenTo() {
+    return ProjectEntity
+  }
+
+  afterLoad(entity: ProjectEntity) {
+    if (Array.isArray(entity.tags)) {
+      entity.tags.sort((a, b) => {
+        if (a.name === undefined || b.name === undefined) {
+          return 0
+        }
+        return a.name.localeCompare(b.name)
+      })
+    }
+    if (Array.isArray(entity.workspaces)) {
+      entity.workspaces.sort((a, b) => {
+        if (
+          b.createdAt === undefined ||
+          a.createdAt === undefined
+        ) {
+          return 0
+        }
+        return b.createdAt.getTime() - a.createdAt.getTime()
+      })
+    }
+    if (Array.isArray(entity.repositories)) {
+      entity.repositories.sort((a, b) => {
+        if (
+          b.createdAt === undefined ||
+          a.createdAt === undefined
+        ) {
+          return 0
+        }
+        return b.createdAt.getTime() - a.createdAt.getTime()
+      })
+    }
+  }
+}


### PR DESCRIPTION
Introduces a new TypeORM subscriber that automatically sorts the tags, workspaces, and repositories relations of ProjectEntity after loading. Updates data source configuration to load subscribers dynamically from the subscribers directory.