### PR TITLE
Add file import to project form description field

### DIFF
--- a/src/main/services/fs.ts
+++ b/src/main/services/fs.ts
@@ -1,9 +1,36 @@
 import { OpenDirDialogResult } from "#/results/open-dir-dialog.result"
 import { app, dialog, shell } from "electron"
-import { existsSync } from "fs"
+import { existsSync, readFileSync, statSync } from "fs"
 import { join, normalize } from "path"
 import { z } from "zod/v4"
 import { registerIpcMainServices } from "./core"
+
+const readFileContent = async () => {
+  const result = await dialog.showOpenDialog({
+    properties: [
+      "dontAddToRecent",
+      "openFile",
+      "noResolveAliases",
+    ],
+  })
+
+  if (result.canceled) {
+    return null
+  }
+
+  const filePath = result.filePaths.at(0)
+  if (filePath === undefined) {
+    return null
+  }
+
+  const fileStat = statSync(filePath)
+  if (!fileStat.isFile()) {
+    return null
+  }
+
+  const content = readFileSync(filePath)
+  return String(content)
+}
 
 const openDirDialog = async (arg: unknown) => {
   const options = z
@@ -63,4 +90,5 @@ registerIpcMainServices("fs", {
   openPath,
   openURL,
   openDatabasePath,
+  readFileContent,
 })

--- a/src/preload/fs.gen.d.ts
+++ b/src/preload/fs.gen.d.ts
@@ -1,7 +1,7 @@
 export declare global {
       interface Window {
         ["fs"]: {
-          openDirDialog: (...args: any[]) => Promise<unknown>,openPath: (...args: any[]) => Promise<unknown>,openURL: (...args: any[]) => Promise<unknown>,openDatabasePath: (...args: any[]) => Promise<unknown>
+          openDirDialog: (...args: any[]) => Promise<unknown>,openPath: (...args: any[]) => Promise<unknown>,openURL: (...args: any[]) => Promise<unknown>,openDatabasePath: (...args: any[]) => Promise<unknown>,readFileContent: (...args: any[]) => Promise<unknown>
         }
       }
     }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -10,6 +10,5 @@ ipcRenderer
         registerIpcRendererServices(name),
       ),
     )
-    console.debug(providers)
   })
   .catch((err) => console.warn(err))

--- a/src/renderer/api/file-system.service.ts
+++ b/src/renderer/api/file-system.service.ts
@@ -1,5 +1,6 @@
 import { openDirDialogResultSchema } from "#/results/open-dir-dialog.result"
 import { left, right } from "fp-ts/lib/Either"
+import z from "zod/v4"
 
 export class FileSystemService {
   private static provider = window["fs"]
@@ -24,6 +25,20 @@ export class FileSystemService {
   static async openDbPath() {
     return this.provider
       .openDatabasePath()
+      .then((resp) => right(resp))
+      .catch((err) => left(err))
+  }
+  static async readFileContent() {
+    return this.provider
+      .readFileContent()
+      .then((resp) =>
+        z
+          .string()
+          .trim()
+          .normalize()
+          .nullable()
+          .parseAsync(resp),
+      )
       .then((resp) => right(resp))
       .catch((err) => left(err))
   }

--- a/src/renderer/components/form/ProjectForm.tsx
+++ b/src/renderer/components/form/ProjectForm.tsx
@@ -10,6 +10,7 @@ import {
 import { useForm } from "@tanstack/react-form"
 import { memo, type FC } from "react"
 import { AutocompleteTextField } from "../input/AutocompeleteTextField"
+import { TextFieldFileContentInput } from "../input/text-field-file-content-input"
 
 type Props = {
   init?: ProjectFormData
@@ -46,15 +47,21 @@ export const ProjectForm: FC<Props> = memo(
           <Stack spacing={1}>
             <Typography>{`NAME`}</Typography>
             <Field name="name">
-              {({ state, handleChange, handleBlur }) => (
+              {({
+                state: { value, meta },
+                handleChange,
+                handleBlur,
+              }) => (
                 <TextField
+                  error={
+                    meta.errors.length > 0 && meta.isTouched
+                  }
                   fullWidth
                   multiline
-                  required
                   minRows={1}
                   onBlur={handleBlur}
                   onChange={(e) => handleChange(e.target.value)}
-                  value={state.value}
+                  value={value}
                 />
               )}
             </Field>
@@ -62,14 +69,20 @@ export const ProjectForm: FC<Props> = memo(
           <Stack spacing={1}>
             <Typography>{`DESCRIPTION`}</Typography>
             <Field name="description">
-              {({ state, handleChange, handleBlur }) => (
-                <TextField
-                  fullWidth
+              {({
+                state: { value, meta },
+                handleChange,
+                handleBlur,
+              }) => (
+                <TextFieldFileContentInput
+                  error={
+                    meta.isTouched && meta.errors.length > 0
+                  }
+                  value={value}
+                  onChange={handleChange}
+                  minRows={5}
                   multiline
-                  minRows={4}
                   onBlur={handleBlur}
-                  onChange={(e) => handleChange(e.target.value)}
-                  value={state.value}
                 />
               )}
             </Field>
@@ -78,16 +91,20 @@ export const ProjectForm: FC<Props> = memo(
             <Typography>{`TAGS`}</Typography>
             <Field name="tagNames" mode="array">
               {({
-                state,
+                state: { value, meta },
                 removeValue,
                 pushValue,
                 handleBlur,
               }) => (
                 <Stack spacing={0.5}>
                   <AutocompleteTextField
+                    error={
+                      meta.isTouched && meta.errors.length > 0
+                    }
+                    placeholder={`${value.length} SELECTED`}
                     onSelect={pushValue}
                     options={formOptions.tags}
-                    disabledOptions={state.value}
+                    disabledOptions={value}
                     onBlur={handleBlur}
                   />
                   <Stack
@@ -96,7 +113,7 @@ export const ProjectForm: FC<Props> = memo(
                     flexWrap="wrap"
                     useFlexGap
                   >
-                    {state.value.map((_, index) => (
+                    {value.map((_, index) => (
                       <Field
                         key={index}
                         name={`tagNames[${index}]`}

--- a/src/renderer/components/input/AutocompeleteTextField.tsx
+++ b/src/renderer/components/input/AutocompeleteTextField.tsx
@@ -9,9 +9,11 @@ type Props = {
   options: Array<string>
   disabledOptions: Array<string>
   onBlur: () => unknown
+  error?: boolean
 }
 export const AutocompleteTextField: FC<Props> = memo(
   ({
+    error,
     onBlur,
     onSelect,
     placeholder,
@@ -76,7 +78,11 @@ export const AutocompleteTextField: FC<Props> = memo(
         onInputChange={handleInputChange}
         fullWidth
         renderInput={(params) => (
-          <TextField {...params} placeholder={placeholder} />
+          <TextField
+            {...params}
+            placeholder={placeholder}
+            error={error}
+          />
         )}
         options={options}
         getOptionDisabled={getDisabledOptions}

--- a/src/renderer/components/input/text-field-file-content-input.tsx
+++ b/src/renderer/components/input/text-field-file-content-input.tsx
@@ -1,0 +1,50 @@
+import { FileSystemService } from "@/api/file-system.service"
+import {
+  Stack,
+  TextField,
+  type TextFieldProps,
+} from "@mui/material"
+import { isRight } from "fp-ts/lib/Either"
+import { useRef, type FC } from "react"
+import { TypographyButton } from "./typography-button"
+
+type Props = {
+  value: string
+  onChange: (v: string) => unknown
+} & Omit<TextFieldProps, "value" | "onChange">
+export const TextFieldFileContentInput: FC<Props> = ({
+  onChange,
+  value,
+  ...rest
+}) => {
+  const dialogActiveRef = useRef(false)
+
+  return (
+    <Stack spacing={1}>
+      <TypographyButton
+        onClick={async () => {
+          if (dialogActiveRef.current) {
+            return
+          }
+          dialogActiveRef.current = true
+          const result =
+            await FileSystemService.readFileContent().finally(
+              () => {
+                dialogActiveRef.current = false
+              },
+            )
+          if (isRight(result) && result.right !== null) {
+            onChange(result.right)
+          }
+        }}
+      >
+        [IMPORT FROM FILE]
+      </TypographyButton>
+      <TextField
+        {...rest}
+        onChange={(e) => onChange(e.target.value)}
+        value={value}
+      />
+    </Stack>
+  )
+}


### PR DESCRIPTION
Introduced a new TextFieldFileContentInput component that allows users to import file content into the project description field. Added a readFileContent IPC service and integrated error handling and validation for form fields. Updated ProjectForm and AutocompleteTextField to support error display and improved form usability.