### PR TITLE
Remove duplicate options in autocomplete fields

### DIFF
--- a/src/renderer/components/form/project-query-form.tsx
+++ b/src/renderer/components/form/project-query-form.tsx
@@ -1,4 +1,5 @@
 import { Autocomplete, Stack, TextField } from "@mui/material"
+import { uniq } from "lodash"
 import { memo, useMemo, useRef, useState, type FC } from "react"
 import { useHotkeys } from "react-hotkeys-hook"
 import { StyledLink } from "../navigation/styled-link"
@@ -12,7 +13,7 @@ type Props = {
 export const ProjectQueryForm: FC<Props> = memo(
   ({ formOptions }) => {
     const options = useMemo(() => {
-      return formOptions.tags
+      return uniq(formOptions.tags)
         .map((opt) => [
           {
             label: `tag:"${opt}"`,
@@ -20,7 +21,7 @@ export const ProjectQueryForm: FC<Props> = memo(
           },
         ])
         .concat(
-          formOptions.projects.map((opt) => [
+          uniq(formOptions.projects).map((opt) => [
             {
               label: `name:"${opt}"`,
               value: `name:${opt}`,

--- a/src/renderer/components/input/AutocompeleteTextField.tsx
+++ b/src/renderer/components/input/AutocompeleteTextField.tsx
@@ -3,6 +3,7 @@ import type {
   FilterOptionsState,
 } from "@mui/material"
 import { Autocomplete, TextField } from "@mui/material"
+import { uniq } from "lodash"
 import { matchSorter } from "match-sorter"
 import type { FC } from "react"
 import { memo, useCallback, useMemo, useState } from "react"
@@ -71,17 +72,19 @@ export const AutocompleteTextField: FC<Props> = memo(
       },
       [disabledOptionsSet],
     )
-    const filterOptions = useCallback(
-      (options: string[], state: FilterOptionsState<string>) => {
-        return state.inputValue
+    const filterOptions = (
+      options: string[],
+      state: FilterOptionsState<string>,
+    ) => {
+      return uniq(
+        state.inputValue
           .split(" ")
           .reduceRight(
             (results, term) => matchSorter(results, term),
             options,
-          )
-      },
-      [options],
-    )
+          ) satisfies string[],
+      )
+    }
 
     return (
       <Autocomplete
@@ -100,7 +103,7 @@ export const AutocompleteTextField: FC<Props> = memo(
             error={error}
           />
         )}
-        options={options}
+        options={uniq(options)}
         getOptionDisabled={getDisabledOptions}
         onBlur={onBlur}
       />


### PR DESCRIPTION
Applied lodash's uniq to ensure tags, projects, and autocomplete options are unique in project-query-form and AutocompleteTextField components. This prevents duplicate entries from appearing in dropdowns and improves user experience.