### PR TITLE
Refactor project creation flow and schema usage

### DIFF
--- a/src/main/db/service/project.service.ts
+++ b/src/main/db/service/project.service.ts
@@ -146,13 +146,17 @@ const unpin = async (arg: unknown) => {
 const create = async (arg: unknown) => {
   const dto = createProjectDtoSchema.parse(arg)
   return AppDataSource.transaction(async (mgr) => {
+    const repo = mgr.getRepository(ProjectEntity)
     const tags = await _fillTags(mgr, dto)
-    const project = mgr.create(ProjectEntity, {
+    const project = repo.create({
       ...dto,
       pinned: false,
       tags,
     })
-    return mgr.save(ProjectEntity, project)
+    const { uuid } = await repo.save(project)
+    return _fromTableEntity(
+      await repo.findOneOrFail({ where: { uuid } }),
+    )
   })
 }
 

--- a/src/renderer/api/project.service.ts
+++ b/src/renderer/api/project.service.ts
@@ -1,6 +1,6 @@
 import type { CreateProjectDto } from "#/models/project/dto/create-project.dto"
 import type { UpsertProjectDto } from "#/models/project/dto/upsert-project.dto"
-import { projectSchema } from "#/models/project/project"
+import { ProjectSchema } from "#/models/project/project"
 import { left, right } from "fp-ts/lib/Either"
 import z from "zod"
 
@@ -10,7 +10,7 @@ export class ProjectService {
   static async list(query: string[]) {
     return this.provider
       .list(query)
-      .then((resp) => projectSchema.array().parseAsync(resp))
+      .then((resp) => ProjectSchema.array().parseAsync(resp))
   }
 
   static async listNames() {
@@ -22,7 +22,7 @@ export class ProjectService {
   static async findByUuid(uuid: string) {
     return this.provider
       .findByUuid(uuid)
-      .then((resp) => projectSchema.parseAsync(resp))
+      .then((resp) => ProjectSchema.parseAsync(resp))
       .then((resp) => right(resp))
       .catch((err) => left(err))
   }
@@ -30,7 +30,11 @@ export class ProjectService {
     return this.provider.upsert(dto)
   }
   static async create(dto: CreateProjectDto) {
-    return this.provider.create(dto)
+    return this.provider
+      .create(dto)
+      .then((resp) => ProjectSchema.parseAsync(resp))
+      .then((resp) => right(resp))
+      .catch((err) => left(err))
   }
   static async createFromPaths(paths: string[]) {
     return this.provider.createFromPaths(paths)

--- a/src/renderer/routes/projects/create.tsx
+++ b/src/renderer/routes/projects/create.tsx
@@ -4,6 +4,7 @@ import { ProjectForm } from "@/components/form/ProjectForm"
 import type { ProjectFormData } from "@/types/project-form-data"
 import { Paper } from "@mui/material"
 import { createFileRoute } from "@tanstack/react-router"
+import { isRight } from "fp-ts/lib/Either"
 import type { FC } from "react"
 import { memo, useCallback } from "react"
 import { toast } from "react-toastify"
@@ -13,15 +14,18 @@ const RouteComponent: FC = memo(() => {
   const navigate = Route.useNavigate()
 
   const handleSubmit = useCallback((data: ProjectFormData) => {
-    ProjectService.create(data).then(
-      () => {
+    ProjectService.create(data).then((resp) => {
+      if (isRight(resp)) {
         toast.success("project added")
-        return navigate({ to: "/projects" })
-      },
-      () => {
+        return navigate({
+          to: "/projects/$uuid",
+          params: { uuid: resp.right.uuid },
+        })
+      } else {
         toast.error("failed to add project")
-      },
-    )
+        return
+      }
+    })
   }, [])
   return (
     <Paper variant="outlined">

--- a/src/shared/models/project/project.ts
+++ b/src/shared/models/project/project.ts
@@ -2,7 +2,7 @@ import { z } from "zod/v4"
 
 const nameString = z.string().trim().normalize().nonempty()
 const descString = z.string().trim().normalize().nullable()
-export const projectSchema = z.object({
+export const ProjectSchema = z.object({
   uuid: z.uuidv4(),
   name: nameString,
   pinned: z.boolean(),
@@ -34,4 +34,4 @@ export const projectSchema = z.object({
     .array(),
 })
 
-export type Project = z.infer<typeof projectSchema>
+export type Project = z.infer<typeof ProjectSchema>


### PR DESCRIPTION
Standardized the project schema export to 'ProjectSchema' and updated all references accordingly. Improved the project creation flow to return the full project entity after creation, added schema validation and error handling in the renderer API, and updated the project creation route to handle success and error cases with navigation and notifications.